### PR TITLE
Fixes for Amazon. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ OPTION( Tinia_DESKTOP "Build qtcontroller?" ON )
 OPTION( Tinia_BUILD_EXAMPLES "Build example jobs?" ON )
 OPTION( Tinia_BUILD_TUTORIALS "Build tutorials?" ON )
 OPTION( Tinia_BUILD_UNIT_TESTS "Build unit tests?" ON )
+OPTION( Tinia_AMAZON "Configurations needed to make Tinia work smoothly on Amazon" OFF)
 
 OPTION( Tinia_EXTEND_CMAKE_MODULE_PATH
         "Extend the CMAKE_MODULE_PATH variable with user directories?"
@@ -51,7 +52,9 @@ IF(WIN32)
 	"${Tinia_3RDPARTY_LOC}" )
 ENDIF()
 
-
+IF(Tinia_AMAZON) 
+  ADD_DEFINITIONS(-DTINIA_AMAZON)
+ENDIF()
 IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCC)
         SET(CMAKE_CXX_FLAGS "-Wall -fPIC -std=c++0x ${CMAKE_CXX_FLAGS}" CACHE STRING " " FORCE)
 ENDIF()

--- a/src/trell_master/RenderingDevices.cpp
+++ b/src/trell_master/RenderingDevices.cpp
@@ -39,7 +39,8 @@ RenderingDevices::RenderingDevices(void (*logger)( void* data, int level, const 
                                    void* logger_data )
     : m_display_name( ":0.0" ),
       m_logger( logger ),
-      m_logger_data( logger_data )
+      m_logger_data( logger_data ),
+      m_hasRenderingInformation(false)
 {
 }
 
@@ -66,7 +67,12 @@ RenderingDevices::parseExtensions( const char* string )
 std::string
 RenderingDevices::xml()
 {
-
+    // We cache the results
+    if(m_hasRenderingInformation) {
+      std::cout << m_xml<<std::endl;
+        return m_xml;
+    }
+    
     std::stringstream xml;
     xml << "  <renderingDevices>\n";
    
@@ -96,7 +102,11 @@ RenderingDevices::xml()
                 continue;
             }
 
-            int screen_count = ScreenCount( display );
+#ifdef TINIA_AMAZON
+            int screen_count = 1;
+#else
+	    int screen_count = ScreenCount ( display );
+#endif
             XCloseDisplay( display );
             
             if( screen_count < 1 ) {
@@ -178,6 +188,8 @@ RenderingDevices::xml()
         closedir( dir );
     }
     xml << "  </renderingDevices>\n";
+    m_hasRenderingInformation = true;
+    m_xml = xml.str();
     return xml.str();
 }
 

--- a/src/trell_master/RenderingDevices.hpp
+++ b/src/trell_master/RenderingDevices.hpp
@@ -39,6 +39,10 @@ protected:
  
     std::list<std::string>
     parseExtensions( const char* string );
+
+private:
+    std::string m_xml;
+    bool        m_hasRenderingInformation;
 };
 
 } // of namespace impl


### PR DESCRIPTION
Made the Render devices-xml-string be cached such that it only needs to be generated once, and we are currently only supporting one display on AWS. 
