### PR TITLE
- Changed to grabbing RGB instead of BGR from FBO.

### DIFF
--- a/include/tinia/trell/trell.h
+++ b/include/tinia/trell/trell.h
@@ -33,8 +33,8 @@ extern "C" {
 
 /** The pixel formats that is used in the trell system. */
 enum TrellPixelFormat {
-    /** 8-bit normalized bgr data. */
-    TRELL_PIXEL_FORMAT_BGR8
+    /** 8-bit normalized rgb data. */
+    TRELL_PIXEL_FORMAT_RGB
 };
 
 /** States that a MessageBox/Master/Job/InteractiveJob can be in */

--- a/src/mod_trell/mod_trell.c
+++ b/src/mod_trell/mod_trell.c
@@ -48,6 +48,7 @@ const module* tinia_get_module()
     return &trell_module;
 }
 
+#if 0
 static int
 tinia_check_and_copy( char* dst, const char* src, int maxlen, request_rec* r, const char* what )
 {
@@ -74,6 +75,7 @@ tinia_check_and_copy( char* dst, const char* src, int maxlen, request_rec* r, co
     }
     return 0;
 }
+#endif
 
 //trell_sconf_t* sconf = ap_get_module_config( f->r->server->module_config, &trell_module );
 

--- a/src/mod_trell/mod_trell_job.c
+++ b/src/mod_trell/mod_trell_job.c
@@ -161,7 +161,7 @@ trell_handle_get_snapshot( trell_sconf_t*          sconf,
 
     tinia_msg_get_snapshot_t query;
     query.msg.type     = TRELL_MESSAGE_GET_SNAPSHOT;
-    query.pixel_format = TRELL_PIXEL_FORMAT_BGR8;
+    query.pixel_format = TRELL_PIXEL_FORMAT_RGB;
     query.width        = dispatch_info->m_width;
     query.height       = dispatch_info->m_height;
     memcpy( query.session_id, dispatch_info->m_sessionid, TRELL_SESSIONID_MAXLENGTH );

--- a/src/mod_trell/pass_reply_png.c
+++ b/src/mod_trell/pass_reply_png.c
@@ -96,7 +96,7 @@ trell_pass_reply_png( void* data,
         }
         
         
-        int i,j;
+        int j;
         int w = encoder_state->width;
         int h = encoder_state->height;
         
@@ -105,13 +105,10 @@ trell_pass_reply_png( void* data,
         char* unfiltered = encoder_state->buffer;
         
         encoder_state->dispatch_info->m_png_filter_entry = apr_time_now();
+        // We use png filter "none", and do a vertical flipping of the image
         for( j=0; j<h; j++ ) {
             filtered[ (3*w+1)*j + 0 ] = 0;
-            for( i=0; i<w; i++ ) {
-                filtered[ (3*w+1)*j + 1 + 3*i + 0 ] = unfiltered[ 3*w*(h-j-1) + 3*i + 2 ];
-                filtered[ (3*w+1)*j + 1 + 3*i + 1 ] = unfiltered[ 3*w*(h-j-1) + 3*i + 1 ];
-                filtered[ (3*w+1)*j + 1 + 3*i + 2 ] = unfiltered[ 3*w*(h-j-1) + 3*i + 0 ];
-            }
+            memcpy( filtered + (3*w+1)*j + 1, unfiltered + 3*w*(h-j-1), w*3 );
         }
         encoder_state->dispatch_info->m_png_filter_exit = apr_time_now();
         

--- a/src/trell/IPCGLJobController.cpp
+++ b/src/trell/IPCGLJobController.cpp
@@ -492,8 +492,8 @@ IPCGLJobController::onGetSnapshot( char*               buffer,
     glBindFramebuffer( GL_FRAMEBUFFER, env_copy->m_fbo );
     glPixelStorei( GL_PACK_ALIGNMENT, 1 );
     switch( pixel_format ) {
-    case TRELL_PIXEL_FORMAT_BGR8:
-        glReadPixels( 0, 0, width, height, GL_BGR, GL_UNSIGNED_BYTE, buffer );
+    case TRELL_PIXEL_FORMAT_RGB:
+        glReadPixels( 0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, buffer );
         break;
     default:
         if( m_logger_callback != NULL ) {

--- a/src/trell/IPCJobController.cpp
+++ b/src/trell/IPCJobController.cpp
@@ -223,7 +223,7 @@ IPCJobController::handle( tinia_msg_t* msg, size_t msg_size, size_t buf_size )
             session = std::string( q->session_id );
             key     = std::string( q->key );
             
-            if( format != TRELL_PIXEL_FORMAT_BGR8 ) {
+            if( format != TRELL_PIXEL_FORMAT_RGB ) {
                 m_logger_callback( m_logger_data, 0, package.c_str(),
                                    "Queried for snapshot, unsupported image format %d.", (int)format );
 


### PR DESCRIPTION
  (Changed name of enum to ..._RGB even though FBO is RGBA,
  to signify that RGB is what we extract, regardless of the
  FBO type.)
- Commented out unused old debug-routine.
