### PR TITLE
Very small change in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,8 +158,8 @@ IF(Tinia_SERVER)
         HINTS "/usr/lib/" "/opt/libjpeg-turbo/lib64/"
     )
     FIND_PATH(TURBOJPEG_INCLUDE_DIR "turbojpeg.h"
-        HINTS "/usr/include/" "/usr/local/include/"
-              "/opt/" "/opt/libjpeg-turbo/" "/opt/libjpeg-turbo/include/"
+        HINTS "/opt/" "/opt/libjpeg-turbo/" "/opt/libjpeg-turbo/include/" 
+              "/usr/include/" "/usr/local/include/"
     )
 
     FIND_PACKAGE( Threads )


### PR DESCRIPTION
Looking for libjpeg-turbo in the default install location before /usr/include.

Since libjpeg-turbo can be used to more than tinia, the libraries sometimes exist on the system as part of another package. If we have installed libjpeg-turbo ourselves, it is most likely found in the /opt/ folder, and we should therefore look for the libraries there before we look in /usr/include.

This was found to be a problem for at least two persons, and the restructuring of hint directories commited here fixed their problems.
