### PR TITLE
Think this should have been done from the start, but not entirely sure.

### DIFF
--- a/js/gui/Canvas.js
+++ b/js/gui/Canvas.js
@@ -142,6 +142,9 @@ dojo.declare("gui.Canvas", [dijit._Widget], {
 
 
     resize: function (w, h) {
+        if (this._gl) {
+            this._gl.viewport(0, 0, w, h);
+        }
         this._width = w;
         this._height = h;
         this._setWidthHeight(this.domNode);


### PR DESCRIPTION
It doesn't seem to solve any problem, hence I am wary of just applying it. On the other hand, doesn't seem to break anything either. And; it seems to be required for upcoming  utoProxy with non-power-of-two canvas size.

Also; please see the top of https://www.khronos.org/registry/webgl/specs/1.0.2/#2.3 for possible reasons _not_ to do this... I'm a bit uncertain here.
